### PR TITLE
feat: add mirror between discord and slack for #support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ An ill-named internal discord &lt;=> rocketchat &lt;=> slack chat bridge
   - discord (#internal): enabled
   - slack (#internal): enabled
   - rocketchat (#cakephp): enabled (cakedc only)
+- #support: a mirror for the official support channel
+  - discord (#support): enabled
+  - slack (#support): enabled
 
 ## Adding a new bridge
 

--- a/matterbridge.toml.sigil
+++ b/matterbridge.toml.sigil
@@ -51,3 +51,18 @@ RemoteNickFormat="<{NICK}> "
     [[gateway.inout]]
     account = "slack.dev"
     channel = "internal"
+
+[[gateway]]
+    name   = "support"
+    enable = true
+
+    [[gateway.inout]]
+    account = "discord.dev"
+    channel = "support"
+
+    [gateway.inout.options]
+    WebhookURL = "{{ var "DISCORD_SUPPORT_WEBHOOK_URL" }}"
+
+    [[gateway.inout]]
+    account = "slack.dev"
+    channel = "support"


### PR DESCRIPTION
I've already setup the `DISCORD_SUPPORT_WEBHOOK_URL` environment variable on the server and in the management repo, and also invited the `redvelvet` app to the #support channel on slack.