### PR TITLE
Fix nick format

### DIFF
--- a/matterbridge.toml.sigil
+++ b/matterbridge.toml.sigil
@@ -2,14 +2,12 @@
     [slack.dev]
     PrefixMessagesWithNick = false
     PreserveThreading      = true
-    RemoteNickFormat       = "{NICK}"
     Token                  = "{{ var "SLACK_TOKEN" }}"
 
 [discord]
     [discord.dev]
     AutoWebhooks      = true
     PreserveThreading = true
-    RemoteNickFormat  = "{NICK}"
     Server            = "{{ var "DISCORD_SERVER" }}"
     Token             = "{{ var "DISCORD_TOKEN" }}"
 


### PR DESCRIPTION
Currently messages are sent as `NickMessage` without space.

Use default `<{NICK}> ` format (with space after `>`) to send messages as `<Nick> Message`